### PR TITLE
Disable unnecessary integrity checks during deserialization

### DIFF
--- a/Spriggit.Core/EntryPoint.cs
+++ b/Spriggit.Core/EntryPoint.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO.Abstractions;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Binary.Parameters;
 using Noggog;
 using Noggog.IO;
 using Noggog.WorkEngine;
@@ -9,6 +10,19 @@ namespace Spriggit.Core;
 
 public interface IEntryPoint
 {
+    protected static readonly BinaryWriteParameters NoCheckWriteParameters = new()
+    {
+        ModKey = ModKeyOption.NoCheck,
+        MastersListContent = MastersListContentOption.NoCheck,
+        RecordCount = RecordCountOption.NoCheck,
+        MastersListOrdering = MastersListOrderingOption.NoCheck,
+        NextFormID = NextFormIDOption.NoCheck,
+        FormIDUniqueness = FormIDUniquenessOption.NoCheck,
+        MasterFlag = MasterFlagOption.NoCheck,
+        LightMasterLimit = LightMasterLimitOption.NoCheck,
+        CleanNulls = false
+    };
+
     public Task Serialize(
         ModPath modPath,
         DirectoryPath outputDir,

--- a/Spriggit.Core/Spriggit.Core.csproj
+++ b/Spriggit.Core/Spriggit.Core.csproj
@@ -2,6 +2,7 @@
 
     <ItemGroup>
         <PackageReference Include="Noggog.CSharpExt" />
+        <PackageReference Include="Mutagen.Bethesda.Core" />
         <PackageReference Include="Mutagen.Bethesda.Kernel" />
         <PackageReference Include="NuGet.Versioning" />
     </ItemGroup>

--- a/Translation Packages/Spriggit.Json.Oblivion/EntryPoint.cs
+++ b/Translation Packages/Spriggit.Json.Oblivion/EntryPoint.cs
@@ -50,10 +50,7 @@ public class EntryPoint : IEntryPoint
             fileSystem: fileSystem,
             streamCreator: streamCreator,
             cancel: cancel);
-        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: new BinaryWriteParameters()
-        {
-            ModKey = ModKeyOption.NoCheck
-        });
+        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: IEntryPoint.NoCheckWriteParameters);
     }
 
     private static readonly Mutagen.Bethesda.Serialization.Newtonsoft.NewtonsoftJsonSerializationReaderKernel ReaderKernel = new();

--- a/Translation Packages/Spriggit.Json.Skyrim/EntryPoint.cs
+++ b/Translation Packages/Spriggit.Json.Skyrim/EntryPoint.cs
@@ -50,10 +50,7 @@ public class EntryPoint : IEntryPoint
             fileSystem: fileSystem,
             streamCreator: streamCreator,
             cancel: cancel);
-        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: new BinaryWriteParameters()
-        {
-            ModKey = ModKeyOption.NoCheck
-        });
+        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: IEntryPoint.NoCheckWriteParameters);
     }
 
     private static readonly Mutagen.Bethesda.Serialization.Newtonsoft.NewtonsoftJsonSerializationReaderKernel ReaderKernel = new();

--- a/Translation Packages/Spriggit.Json.Starfield/EntryPoint.cs
+++ b/Translation Packages/Spriggit.Json.Starfield/EntryPoint.cs
@@ -50,10 +50,7 @@ public class EntryPoint : IEntryPoint
             fileSystem: fileSystem,
             streamCreator: streamCreator,
             cancel: cancel);
-        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: new BinaryWriteParameters()
-        {
-            ModKey = ModKeyOption.NoCheck
-        });
+        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: IEntryPoint.NoCheckWriteParameters);
     }
 
     private static readonly Mutagen.Bethesda.Serialization.Newtonsoft.NewtonsoftJsonSerializationReaderKernel ReaderKernel = new();

--- a/Translation Packages/Spriggit.Yaml.Oblivion/EntryPoint.cs
+++ b/Translation Packages/Spriggit.Yaml.Oblivion/EntryPoint.cs
@@ -50,10 +50,7 @@ public class EntryPoint : IEntryPoint
             fileSystem: fileSystem,
             streamCreator: streamCreator,
             cancel: cancel);
-        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: new BinaryWriteParameters()
-        {
-            ModKey = ModKeyOption.NoCheck
-        });
+        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: IEntryPoint.NoCheckWriteParameters);
     }
 
     private static readonly Mutagen.Bethesda.Serialization.Yaml.YamlSerializationReaderKernel ReaderKernel = new();

--- a/Translation Packages/Spriggit.Yaml.Skyrim/EntryPoint.cs
+++ b/Translation Packages/Spriggit.Yaml.Skyrim/EntryPoint.cs
@@ -50,10 +50,7 @@ public class EntryPoint : IEntryPoint
             fileSystem: fileSystem,
             streamCreator: streamCreator,
             cancel: cancel);
-        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: new BinaryWriteParameters()
-        {
-            ModKey = ModKeyOption.NoCheck
-        });
+        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: IEntryPoint.NoCheckWriteParameters);
     }
 
     private static readonly Mutagen.Bethesda.Serialization.Yaml.YamlSerializationReaderKernel ReaderKernel = new();

--- a/Translation Packages/Spriggit.Yaml.Starfield/EntryPoint.cs
+++ b/Translation Packages/Spriggit.Yaml.Starfield/EntryPoint.cs
@@ -50,10 +50,7 @@ public class EntryPoint : IEntryPoint
             fileSystem: fileSystem,
             streamCreator: streamCreator,
             cancel: cancel);
-        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: new BinaryWriteParameters()
-        {
-            ModKey = ModKeyOption.NoCheck
-        });
+        mod.WriteToBinaryParallel(outputPath, fileSystem: fileSystem, param: IEntryPoint.NoCheckWriteParameters);
     }
 
     private static readonly Mutagen.Bethesda.Serialization.Yaml.YamlSerializationReaderKernel ReaderKernel = new();


### PR DESCRIPTION
This commit removes various checks which could unintentionally change mod contents or metadata as it gets deserialized into a plugin. Without this fix, round-tripping could cause differences in the generated files without any intentional user changes.

Some of these unintentional changes are:
- Cleaning or reordering the list of masters
- Changing mod record stats such as record count and next record

Fixes #25.