### PR TITLE
Syncing fails loudly

### DIFF
--- a/Spriggit.UI/ViewModels/Transient/LinkVm.cs
+++ b/Spriggit.UI/ViewModels/Transient/LinkVm.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -204,7 +205,7 @@ public class LinkVm : ViewModel
             if (meta.Failed)
             {
                 _logger.Error("Could not sync to Git {Reason}", meta.Reason);
-                MessageBox.Show("Could not sync \"" + Input.ModPathPicker.TargetPath + "\" to Git: " + meta.Reason, "Could not sync to Git", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show("Could not sync \"" + Path.GetFileName(Input.ModPathPicker.TargetPath) + "\" to Git: " + meta.Reason, "Could not sync to Git", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
@@ -224,7 +225,7 @@ public class LinkVm : ViewModel
         catch (Exception e)
         {
             _logger.Error(e, "Error syncing to Git");
-            MessageBox.Show("Error syncing \"" + Input.ModPathPicker.TargetPath + "\" to Git: " + e.Message, "Error syncing to Git", MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBox.Show("Error syncing \"" + Path.GetFileName(Input.ModPathPicker.TargetPath) + "\" to Git: " + e.Message, "Error syncing to Git", MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
     
@@ -247,7 +248,7 @@ public class LinkVm : ViewModel
         catch (Exception e)
         {
             _logger.Error(e, "Error syncing to Mod");
-            MessageBox.Show("Error syncing \"" + Input.GitFolderPicker.TargetPath + "\" to Mod: " + e.Message, "Error syncing to Mod", MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBox.Show("Error syncing \"" + Path.GetFileName(Input.GitFolderPicker.TargetPath) + "\" to Mod: " + e.Message, "Error syncing to Mod", MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
 

--- a/Spriggit.UI/ViewModels/Transient/LinkVm.cs
+++ b/Spriggit.UI/ViewModels/Transient/LinkVm.cs
@@ -1,7 +1,9 @@
-﻿using System.Reactive;
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Windows;
 using System.Windows.Input;
+using Autofac.Features.Metadata;
 using Noggog;
 using Noggog.WPF;
 using ReactiveUI;
@@ -201,7 +203,8 @@ public class LinkVm : ViewModel
             var meta = MetaToUse;
             if (meta.Failed)
             {
-                _logger.Error("Could not sync to git {Reason}", meta.Reason);
+                _logger.Error("Could not sync to Git {Reason}", meta.Reason);
+                MessageBox.Show("Could not sync \"" + Input.ModPathPicker.TargetPath + "\" to Git: " + meta.Reason, "Could not sync to Git", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
@@ -221,6 +224,7 @@ public class LinkVm : ViewModel
         catch (Exception e)
         {
             _logger.Error(e, "Error syncing to Git");
+            MessageBox.Show("Error syncing \"" + Input.ModPathPicker.TargetPath + "\" to Git: " + e.Message, "Error syncing to Git", MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
     
@@ -243,6 +247,7 @@ public class LinkVm : ViewModel
         catch (Exception e)
         {
             _logger.Error(e, "Error syncing to Mod");
+            MessageBox.Show("Error syncing \"" + Input.GitFolderPicker.TargetPath + "\" to Mod: " + e.Message, "Error syncing to Mod", MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
 


### PR DESCRIPTION
If syncing fails, a MessageBox will be shown with the failure reason or Exception details.

Exceptions and failure reasons could be made more clear, but it's better than it not doing anything, and it will give users something to look up or ask about in the discord.