### PR TITLE
Bugfix: Ensure CultureInfo.InvariantCulture is used

### DIFF
--- a/Spriggit.CLI/Program.cs
+++ b/Spriggit.CLI/Program.cs
@@ -1,4 +1,5 @@
-﻿using CommandLine;
+﻿using System.Globalization;
+using CommandLine;
 using Spriggit.CLI;
 using Spriggit.CLI.Commands;
 

--- a/Spriggit.CLI/Program.cs
+++ b/Spriggit.CLI/Program.cs
@@ -4,6 +4,7 @@ using Spriggit.CLI;
 using Spriggit.CLI.Commands;
 
 CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
 
 return await Parser.Default.ParseArguments(args, typeof(DeserializeCommand), typeof(SerializeCommand))
     .MapResult(

--- a/Spriggit.CLI/Program.cs
+++ b/Spriggit.CLI/Program.cs
@@ -2,6 +2,8 @@
 using Spriggit.CLI;
 using Spriggit.CLI.Commands;
 
+CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+
 return await Parser.Default.ParseArguments(args, typeof(DeserializeCommand), typeof(SerializeCommand))
     .MapResult(
         async (DeserializeCommand deserialize) => await Runner.Run(deserialize),

--- a/Spriggit.UI/Services/Startup.cs
+++ b/Spriggit.UI/Services/Startup.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+using System.Globalization;
+using System.Windows;
 using Serilog;
 using Spriggit.UI.ViewModels;
 using Spriggit.UI.ViewModels.Singletons;
@@ -32,6 +33,9 @@ public class Startup
     
     public void Initialize()
     {
+        CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+
         AppDomain.CurrentDomain.UnhandledException += (_, e) =>
         {
             var ex = e.ExceptionObject as Exception;


### PR DESCRIPTION
If a locale with commas as decimal separators is used by the user, Spriggit cannot deserialize the content it has generated by serializing a file if it contains vectors.

I am using the Italian culture/locale (`it-IT`), where decimal numbers are represented like this:

```
12,34
```

instead of:

```
12.34
```

If we take Skyrim Special Edition's `HearthFires.esm` and we serialize it using the latest release of Spriggit 0.10:

```
Spriggit.CLI.exe serialize --InputPath ".\data\HearthFires.esm" --OutputPath ".\data\src" --GameRelease SkyrimSE --PackageName Spriggit.Yaml
```

We get the yaml files, however commas are used instead of dots for decimal separators.

For example, the file `src/NavigationMeshInfoMaps/012FB4_Skyrim.esm.yaml` has the following content (truncated):

```yaml
FormKey: 012FB4:Skyrim.esm
VersionControl: 4813080
FormVersion: 43
Version2: 12
NavMeshVersion: 12
MapInfos:
- NavigationMesh: 0F13F4:Skyrim.esm
  Unknown: 32
  Point: -16323,98, -67327,94, 1052,3523
  MergedTo:
  - 0E845B:Skyrim.esm
  Island:
    Min: -16384, -67457,68, 1044,3851
    Max: -16236,074, -67201,61, 1060,1609
```

Notice how the P3Floats `Point`, `Min` and `Max` contain multiple commas.

When running Spriggit in deserialize mode against that folder, it cannot parse those P3Floats correctly:

```
λ Spriggit.CLI.exe deserialize --InputPath "data\src" --OutputPath "data\Hearthfires_deserialized.esp" --PackageName Spriggit.Yaml
[02:33:30.979 INF] Command to deserialize
[02:33:31.036 INF] Getting meta to use for Spriggit.Yaml at path data\src
[02:33:31.043 INF] No version specified.  Checking NuGet repositories for latest version
[02:33:31.129 INF] Constructing entry point for Spriggit.Yaml.Skyrim.0.10.0
[02:33:31.132 INF] Getting target framework directory for C:\Users\Giuseppe\AppData\Local\Temp\Spriggit\Sources\Spriggit.Yaml.Skyrim.0.10.0\Spriggit.Yaml.Skyrim.0.10.0
[02:33:31.135 INF] Framework directory located: C:\Users\Giuseppe\AppData\Local\Temp\Spriggit\Sources\Spriggit.Yaml.Skyrim.0.10.0\Spriggit.Yaml.Skyrim.0.10.0\lib\net7.0
[02:33:31.137 INF] Loading plugin: C:\Users\Giuseppe\AppData\Local\Temp\Spriggit\Sources\Spriggit.Yaml.Skyrim.0.10.0\Spriggit.Yaml.Skyrim.0.10.0\lib\net7.0\Spriggit.Yaml.Skyrim.dll
[02:33:31.146 INF] Retrieving default assembly
[02:33:31.149 INF] Finding entry point type
[02:33:31.150 INF] Looking for typically named entry point classes
[02:33:31.162 INF] Creating entry point object
[02:33:31.164 INF] Cached entry point for Spriggit.Yaml.Skyrim.0.10.0
[02:33:31.195 INF] Getting entry point for SpriggitMeta { Source = Spriggit.Yaml, Release = SkyrimSE }
[02:33:31.200 INF] Getting first identity for SpriggitMeta { Source = Spriggit.Yaml, Release = SkyrimSE }
[02:33:31.202 INF] No version specified.  Checking NuGet repositories for latest version
[02:33:31.205 INF] Cached first identity for SpriggitMeta { Source = Spriggit.Yaml, Release = SkyrimSE }: Spriggit.Yaml.Skyrim.0.10.0
[02:33:31.210 INF] Creating directory C:\Users\Giuseppe\Desktop\spriggit\data
[02:33:31.211 INF] Starting to deserialize
Unhandled exception. System.ArgumentException: Could not parse string into P3Float: -16323,98, -67327,94, 1052,3523
   at Mutagen.Bethesda.Serialization.Yaml.YamlSerializationReaderKernel.ReadP3Float(YamlReadingUnit reader) in /home/runner/work/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization.Yaml/YamlSerializationReaderKernel.cs:line 384
   at Mutagen.Bethesda.Skyrim.NavigationMapInfo_Serialization.DeserializeSingleFieldInto[TReadObject](TReadObject reader, ISerializationReaderKernel`1 kernel, INavigationMapInfo obj, SerializationMetaData metaData, String name) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\NavigationMapInfo_Serializations.g.cs:line 146
   at Mutagen.Bethesda.Skyrim.NavigationMapInfo_Serialization.DeserializeInto[TReadObject](TReadObject reader, ISerializationReaderKernel`1 kernel, INavigationMapInfo obj, SerializationMetaData metaData) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\NavigationMapInfo_Serializations.g.cs:line 203
   at Mutagen.Bethesda.Skyrim.NavigationMapInfo_Serialization.Deserialize[TReadObject](TReadObject reader, ISerializationReaderKernel`1 kernel, SerializationMetaData metaData) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\NavigationMapInfo_Serializations.g.cs:line 120
   at Mutagen.Bethesda.Serialization.Yaml.YamlSerializationReaderKernel.ReadLoqui[TObject](YamlReadingUnit reader, SerializationMetaData serializationMetaData, ReadAsync`3 readCall) in /home/runner/work/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization.Yaml/YamlSerializationReaderKernel.cs:line 580
   at Mutagen.Bethesda.Skyrim.NavigationMeshInfoMap_Serialization.DeserializeSingleFieldInto[TReadObject](TReadObject reader, ISerializationReaderKernel`1 kernel, INavigationMeshInfoMap obj, SerializationMetaData metaData, String name) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\NavigationMeshInfoMap_Serializations.g.cs:line 116
   at Mutagen.Bethesda.Skyrim.NavigationMeshInfoMap_Serialization.DeserializeInto[TReadObject](TReadObject reader, ISerializationReaderKernel`1 kernel, INavigationMeshInfoMap obj, SerializationMetaData metaData) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\NavigationMeshInfoMap_Serializations.g.cs:line 143
   at Mutagen.Bethesda.Skyrim.NavigationMeshInfoMap_Serialization.Deserialize[TReadObject](TReadObject reader, ISerializationReaderKernel`1 kernel, SerializationMetaData metaData) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\NavigationMeshInfoMap_Serializations.g.cs:line 90
   at Mutagen.Bethesda.Serialization.Yaml.YamlSerializationReaderKernel.ReadLoqui[TObject](YamlReadingUnit reader, SerializationMetaData serializationMetaData, ReadAsync`3 readCall) in /home/runner/work/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization.Yaml/YamlSerializationReaderKernel.cs:line 580
   at Mutagen.Bethesda.Skyrim.SkyrimMod_Serialization.<>c__5`2.<<DeserializeInto>b__5_105>d.MoveNext() in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\SkyrimMod_Serializations.g.cs:line 1859
--- End of stack trace from previous location ---
   at Mutagen.Bethesda.Serialization.Utility.SerializationHelper.<>c__DisplayClass19_0`4.<<ReadFilePerRecord>b__4>d.MoveNext() in /home/runner/work/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization/Utility/GroupParallelHelper.cs:line 86
--- End of stack trace from previous location ---
   at Noggog.WorkEngine.ParallelWorkDropoff.<>c__DisplayClass13_0`2.<<EnqueueAndWait>b__0>d.MoveNext() in D:\a\CSharpExt\CSharpExt\Noggog.CSharpExt\WorkEngine\ParallelWorkDropoff.cs:line 135
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.<>c__50`1.<<ForEachAsync>b__50_0>d.MoveNext()
--- End of stack trace from previous location ---
   at Noggog.WorkEngine.ParallelWorkDropoff.EnqueueAndWait[TIn,TRet](IEnumerable`1 items, Func`2 action, CancellationToken cancellationToken) in D:\a\CSharpExt\CSharpExt\Noggog.CSharpExt\WorkEngine\ParallelWorkDropoff.cs:line 129
   at Mutagen.Bethesda.Serialization.Utility.SerializationHelper.ReadFilePerRecord[TKernel,TReadObject,TGroup,TObject](StreamPackage streamPackage, TGroup group, String fieldName, SerializationMetaData metaData, TKernel kernel, ReadNamedInto`3 groupReader, ReadAsync`3 itemReader) in /home/runner/work/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization/Mutagen.Bethesda.Serialization/Utility/GroupParallelHelper.cs:line 78
   at Mutagen.Bethesda.Skyrim.SkyrimMod_Serialization.DeserializeInto[TReadObject,TMeta](TReadObject reader, ISerializationReaderKernel`1 kernel, ISkyrimMod obj, IWorkDropoff workDropoff, IFileSystem fileSystem, ICreateStream streamCreator, TMeta extraMeta, ReadInto`3 metaReader, CancellationToken cancel) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\SkyrimMod_Serializations.g.cs:line 2387
   at Mutagen.Bethesda.Skyrim.SkyrimMod_Serialization.Deserialize[TReadObject,TMeta](TReadObject reader, ISerializationReaderKernel`1 kernel, ModKey modKey, SkyrimRelease release, IWorkDropoff workDropoff, IFileSystem fileSystem, ICreateStream streamCreator, TMeta extraMeta, ReadInto`3 metaReader, CancellationToken cancel) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\SkyrimMod_Serializations.g.cs:line 1365
   at Mutagen.Bethesda.Serialization.Yaml.MutagenYamlConverterSkyrimModMixIns.DeserializeInternal[TMeta](MutagenYamlConverter converterBootstrap, DirectoryPath path, IWorkDropoff workDropoff, IFileSystem fileSystem, ICreateStream streamCreator, TMeta extraMeta, ReadInto`3 metaReader, Nullable`1 cancel) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\MutagenYamlConverter_SkyrimMod_MixIns.g.cs:line 116
   at Mutagen.Bethesda.Serialization.Yaml.MutagenYamlConverterSkyrimModMixIns.Deserialize(MutagenYamlConverter converterBootstrap, DirectoryPath path, Object extraMeta, IWorkDropoff workDropoff, IFileSystem fileSystem, ICreateStream streamCreator, Nullable`1 cancel) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\Mutagen.Bethesda.Serialization.SourceGenerator\Mutagen.Bethesda.Serialization.SourceGenerator.Serialization.SerializationSourceGenerator\MutagenYamlConverter_SkyrimMod_MixIns.g.cs:line 139
   at Spriggit.Yaml.Skyrim.EntryPoint.Deserialize(String inputPath, String outputPath, IWorkDropoff workDropoff, IFileSystem fileSystem, ICreateStream streamCreator, CancellationToken cancel) in D:\a\Spriggit\Spriggit\Translation Packages\Spriggit.Yaml.Skyrim\EntryPoint.cs:line 60
   at Spriggit.Engine.SpriggitEngine.Deserialize(String spriggitPluginPath, FilePath outputFile, SpriggitSource source, CancellationToken cancel) in D:\a\Spriggit\Spriggit\Spriggit.Engine\SpriggetEngine.cs:line 80
   at Spriggit.CLI.Runner.Run(DeserializeCommand deserializeCommand) in D:\a\Spriggit\Spriggit\Spriggit.CLI.Lib\Runner.cs:line 56
   at Program.<>c.<<<Main>$>b__0_0>d.MoveNext() in D:\a\Spriggit\Spriggit\Spriggit.CLI\Program.cs:line 7
--- End of stack trace from previous location ---
   at Program.<Main>$(String[] args) in D:\a\Spriggit\Spriggit\Spriggit.CLI\Program.cs:line 5
   at Program.<Main>(String[] args)
```

---

This PR ensures that [CultureInfo.InvariantCulture](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.invariantculture?view=net-7.0) is used, so that a dot is always used as a decimal separator, regardless of the user's locale.

With this PR and an `it-IT` locale, the yaml for `src/NavigationMeshInfoMaps/012FB4_Skyrim.esm.yaml` becomes like so (truncated):

```yaml
FormKey: 012FB4:Skyrim.esm
VersionControl: 4813080
FormVersion: 43
Version2: 12
NavMeshVersion: 12
MapInfos:
- NavigationMesh: 0F13F4:Skyrim.esm
  Unknown: 32
  Point: -16323.98, -67327.94, 1052.3523
  MergedTo:
  - 0E845B:Skyrim.esm
  Island:
    Min: -16384, -67457.68, 1044.3851
    Max: -16236.074, -67201.61, 1060.1609
```

and this time it can be deserialized properly.