### PR TITLE
add 0.38.7 winget manifest

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -167,6 +167,12 @@ jobs:
     - name: Print Packages
       run: |
         ls out/*.nupkg
+    - name: Release CLI winget package
+      uses: vedantmgoyal9/winget-releaser@main
+      with:
+        identifier: MutagenModding.Spriggit.CLI
+        installers-regex: '.\SpriggitCLI.zip'
+        token: ${{ secrets.WINGET_TOKEN }}
     - name: Publish to Nuget.org
       run: dotnet nuget push out/**/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
   

--- a/manifests/m/MutagenModding/Spriggit/0.38.7/MutagenModding.Spriggit.installer.yaml
+++ b/manifests/m/MutagenModding/Spriggit/0.38.7/MutagenModding.Spriggit.installer.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: MutagenModding.Spriggit
+PackageVersion: 0.38.7
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: Spriggit.CLI.exe
+  PortableCommandAlias: spriggit
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Mutagen-Modding/Spriggit/releases/download/0.38.7/SpriggitCLI.zip
+  InstallerSha256: 943C59343E9A1BE2A7021AB8E450B760AB22BF447E21E402B80BE4D8C29773E1
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/m/MutagenModding/Spriggit/0.38.7/MutagenModding.Spriggit.locale.en-US.yaml
+++ b/manifests/m/MutagenModding/Spriggit/0.38.7/MutagenModding.Spriggit.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: MutagenModding.Spriggit
+PackageVersion: 0.38.7
+PackageLocale: en-US
+Publisher: Mutagen Modding
+PublisherUrl: https://mutagen-modding.github.io/Spriggit/
+PublisherSupportUrl: https://github.com/Mutagen-Modding/Spriggit/issues
+Author: https://github.com/Mutagen-Modding
+PackageName: Spriggit
+License: GPL-3.0
+LicenseUrl: https://github.com/Mutagen-Modding/Spriggit/blob/dev/LICENSE
+ShortDescription: A tool to facilitate converting Bethesda plugin files to a text based format that can be stored in Git.
+Description: A tool to facilitate converting Bethesda plugin files to a text based format that can be stored in Git. Large scale projects can then live in Github, and accept Pull Requests from many developers.
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/m/MutagenModding/Spriggit/0.38.7/MutagenModding.Spriggit.yaml
+++ b/manifests/m/MutagenModding/Spriggit/0.38.7/MutagenModding.Spriggit.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: MutagenModding.Spriggit
+PackageVersion: 0.38.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
This would be the first winget manifest. We can update https://github.com/Mutagen-Modding/Spriggit/blob/dev/.github/workflows/ci-publish.yml to call:

```shell
wingetcreate update --urls https://github.com/Mutagen-Modding/Spriggit/releases/download/<NEW RELEASE VERSION>/Spriggit.zip --version <NEW RELEASE VERSION> MutagenModding.Spriggit
```

This will automatically make the new manifest and push the PR to https://github.com/microsoft/winget-pkgs for the new version. For this original version, we'll need to make the PR on `winget-pkgs` after this manifest is merged. I don't even think we even need the manifests in spriggit but it would be nice to keep them.